### PR TITLE
e-sink.el: fix startup time

### DIFF
--- a/e-sink.el
+++ b/e-sink.el
@@ -163,8 +163,9 @@
   (with-current-buffer name
     (unless (cdr (assq :e-sink-in-progress e-sink-data-alist))
       (error "Buffer '%s' doesn't have an active e-sink session"))
-    (goto-char (point-max))
-    (insert data))
+    (save-excursion
+      (goto-char (point-max))
+      (insert data)))
   (format "received %i characters." (length data)))
 
 (defun e-sink-insert-from-temp (transformed-buffer-name &optional no-reschedule)
@@ -174,18 +175,19 @@
       (error "Buffer '%s' doesn't have an active e-sink session"))
     (let ((pos-cons (assq :temp-file-pos e-sink-data-alist))
           (timer-cons (assq :timer e-sink-data-alist)))
-      (goto-char (point-max))
-      (setcdr pos-cons
-              (+
-               (cdr pos-cons)
-               (cadr (insert-file-contents (cdr (assq :temp-file e-sink-data-alist)) nil (cdr pos-cons) nil))))
-      (goto-char (point-max))
-      (setcdr timer-cons (if no-reschedule
-                             nil
-                           (run-at-time s-sink-refresh-rate
-                                        nil
-                                        'e-sink-insert-from-temp
-                                        transformed-buffer-name))))))
+      (save-excursion
+	(goto-char (point-max))
+	(setcdr pos-cons
+		(+
+		 (cdr pos-cons)
+		 (cadr (insert-file-contents (cdr (assq :temp-file e-sink-data-alist)) nil (cdr pos-cons) nil))))
+	(goto-char (point-max))
+	(setcdr timer-cons (if no-reschedule
+			       nil
+			     (run-at-time s-sink-refresh-rate
+					  nil
+					  'e-sink-insert-from-temp
+					  transformed-buffer-name)))))))
 
 (defun e-sink-finish (name &optional signal)
   "finish e-sink session."


### PR DESCRIPTION
The first two options that run-at-time() take are: when to execute
first, and how often to repeat.  Give the startup a different (and
much smaller value) than the repeat time.  While at it, use the the
repeat parameter of run-at-time(), instead of setting up a repeat by
hand in e-sink-insert-from-temp().
